### PR TITLE
#41 Fix encoding dla usługi

### DIFF
--- a/api/add_service.py
+++ b/api/add_service.py
@@ -60,7 +60,7 @@ class AddOGCService:
         redirect_url = reply.attribute(QNetworkRequest.RedirectionTargetAttribute)
         if redirect_url:
             return AddOGCService.fetch_capabilities(redirect_url.toString())
-        capabilities_xml = reply.readAll().data().decode()
+        capabilities_xml = reply.readAll().data().decode('utf-8')
         reply.deleteLater()
         return capabilities_xml
 
@@ -76,8 +76,9 @@ class AddOGCService:
                 with get_legacy_session().get(url=get_capabilities, verify=False) as resp:
                     if resp.status_code != 200:
                         return False
-                    capabilities_xml = resp.content.decode()
-            except requests.exceptions.ConnectionError:
+                    capabilities_xml = resp.content.decode('utf-8')
+            except:
+                # Fragment niezgodny ze standardem
                 return False
         try:
             return AddOGCService.process_service(service_type, capabilities_xml, url)


### PR DESCRIPTION
PR naprawia te 2 błędy:
```2024-11-25T21:05:19     WARNING    Traceback (most recent call last):
              File "C:\Users/wojta/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\web_service_plugin\web_service_plugin.py", line 205, in add_service
              add_layer = AddOGCService.add_service(url, service_type)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
              File "C:\Users/wojta/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\web_service_plugin\api\add_service.py", line 79, in add_service
              capabilities_xml = resp.content.decode()
              ^^^^^^^^^^^^^^^^^^^^^
             UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb3 in position 404: invalid start byte
             
2024-11-25T21:08:26     WARNING    Traceback (most recent call last):
              File "C:\Users/wojta/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\web_service_plugin\web_service_plugin.py", line 205, in add_service
              add_layer = AddOGCService.add_service(url, service_type)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
              File "C:\Users/wojta/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\web_service_plugin\api\add_service.py", line 71, in add_service
              capabilities_xml = AddOGCService.fetch_capabilities(get_capabilities)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
              File "C:\Users/wojta/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\web_service_plugin\api\add_service.py", line 63, in fetch_capabilities
              capabilities_xml = reply.readAll().data().decode()
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb3 in position 404: invalid start byte
```
             

Działo się to np. dla pomorskiego, powiat Sopot (chyba)